### PR TITLE
Allow to define additional forwarding ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This role installs a plain caddy server on a Debian-based system and can, if you
 
 If you only want to install Caddy, you don't need to set any variables. If you want to configure Caddy as a reverse proxy as well, you can provide an array of objects named `caddy_sites` with the following values:
 
-* `domain`: The domain caddy should listen to.
-* `reverse_proxy`: The path to the app where you want to forward the request.
+* `additional_forwarding_ports`: Allows to define a list with additional ports where Caddy should listen for this domain and forward to HTTPS.
+* `allowlist`: An array if IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
-* `allowlist`: An array if IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
+* `domain`: The domain caddy should listen to.
+* `reverse_proxy`: The path to the app where you want to forward the request.
 
 ## Sample playbooks
 

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -23,4 +23,11 @@
   tls {{ site.certificate_file }} {{ site.certificate_key }}
   {% endif %}
 }
+
+{% if site.additional_forwarding_ports | length > 0 %}
+{{ (["http://"] | product([site.domain]) | map("join")) | product(site.additional_forwarding_ports) | map("join", ":") | join(", ") }} {
+  redir http://{{ site.domain }}{uri} permanent
+}
+{% endif %}
+
 {% endfor %}

--- a/test/Caddyfile.expected
+++ b/test/Caddyfile.expected
@@ -18,3 +18,10 @@ example.com {
   
   
 }
+
+
+http://example.com:8080, http://example.com:1337 {
+  redir http://example.com{uri} permanent
+}
+
+

--- a/test/provision-test-installation.yml
+++ b/test/provision-test-installation.yml
@@ -2,25 +2,6 @@
 - hosts: "localhost"
   become: yes
 
-  vars:
-    caddy_sites:
-    - domain: "example.com"
-      reverse_proxy: "192.168.50.2"
-      allowlist: &default_allowlist
-        - "8.8.8.8/32"
-
-  tasks:
-    - name: Copy file to test results
-      copy:
-        src: "{{ playbook_dir }}/Caddyfile.expected"
-        dest: "/etc/caddy/Caddyfile"
-      register: result
-
-    - name: "Fail if template has been changed"
-      fail:
-        msg: "Caddyfile has been changed!"
-      when: result is changed
-
   roles:
     - role: caddy
       tags: caddy

--- a/test/provision-test-proxy.yml
+++ b/test/provision-test-proxy.yml
@@ -2,6 +2,28 @@
 - hosts: "localhost"
   become: yes
 
+  vars:
+    caddy_sites:
+    - domain: "example.com"
+      reverse_proxy: "192.168.50.2"
+      allowlist: &default_allowlist
+        - "8.8.8.8/32"
+      additional_forwarding_ports:
+        - "8080"
+        - "1337"
+
+  tasks:
+    - name: Copy file to test results
+      copy:
+        src: "{{ playbook_dir }}/Caddyfile.expected"
+        dest: "/etc/caddy/Caddyfile"
+      register: result
+
+    - name: "Fail if template has been changed"
+      fail:
+        msg: "Caddyfile has been changed!"
+      when: result is changed
+
   roles:
     - role: caddy
       tags: caddy


### PR DESCRIPTION
This PR allows to define additional HTTP ports for a site where Caddy should listen and forward them to "normal" HTTPS. Primary use case is forwarding of Tomcat's 8080 to https.