### PR TITLE
Support multiple routes per site

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ If you only want to install Caddy, you don't need to set any variables. If you w
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
 * `domain`: The domain caddy should listen to.
-* `reverse_proxy`: The path to the app where you want to forward the request.
+
+Afterwards, you can define a list of `routes` composing of the following values:
+
+* `path`: Path that should be matched. Let it empty for everything or e.g. `/api/*` for something specific.
+* `reverse_proxy_destination`: Where the requested should be proxied.
+* `strip_prefix`: If set, the matched `path` will be removed from the request to the destination system. This means, if somebody requests the route `/api/v1/hello` at the reverse proxy and you set `/api/*` as path, the request will be sent as `/v1/hello` to the destination system.
+
+Certificates, domain etc. are always defined for one site and cannot be redefined for a route.
 
 ## Sample playbooks
 

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -5,29 +5,40 @@
 
 {% for site in caddy_sites %}
 {{ site.domain }} {
-  {% if site.allowlist is defined %}
+  {%- if site.allowlist is defined %}
   @allowlist {
-    remote_ip {%- for ip in site.allowlist %} {{ ip }}{% endfor %}
+    remote_ip {% for ip in site.allowlist %} {{ ip }}{% endfor %}
   }
 
   @not_allowlist {
-    not remote_ip {%- for ip in site.allowlist %} {{ ip }}{% endfor %}
+    not remote_ip {% for ip in site.allowlist %} {{ ip }}{% endfor %}
   }
-
-  reverse_proxy @allowlist {{ site.reverse_proxy }}
-  respond @not_allowlist 404
-  {% else %}
-  reverse_proxy {{ site.reverse_proxy }}
   {% endif %}
+
+  {%- for route in site.routes %}
+  {% if route.strip_prefix is defined and route.strip_prefix %}
+  handle_path {{ route.path }} {
+  {% else %}
+  handle {{ route.path }} {
+  {%- endif %}
+    {%- if site.allowlist is defined %}
+    reverse_proxy @allowlist {{ route.reverse_proxy_destination }}
+    respond @not_allowlist 404
+    {%- else %}
+    reverse_proxy {{ route.reverse_proxy_destination }}
+    {%- endif %}
+  }
+  {%- endfor %}
+  
   {% if site.certificate_file is defined %}
   tls {{ site.certificate_file }} {{ site.certificate_key }}
-  {% endif %}
+  {% endif -%}
 }
 
 {% if site.additional_forwarding_ports | length > 0 %}
 {{ (["http://"] | product([site.domain]) | map("join")) | product(site.additional_forwarding_ports) | map("join", ":") | join(", ") }} {
   redir http://{{ site.domain }}{uri} permanent
 }
-{% endif %}
+{%- endif %}
 
 {% endfor %}

--- a/test/Caddyfile.expected
+++ b/test/Caddyfile.expected
@@ -4,24 +4,24 @@
 
 
 example.com {
-  
   @allowlist {
-    remote_ip 8.8.8.8/32
+    remote_ip  8.8.8.8/32
   }
 
   @not_allowlist {
-    not remote_ip 8.8.8.8/32
+    not remote_ip  8.8.8.8/32
   }
-
-  reverse_proxy @allowlist 192.168.50.2
-  respond @not_allowlist 404
   
   
-}
+  handle  {
+    reverse_proxy @allowlist 192.168.50.2
+    respond @not_allowlist 404
+  }
+  
+  }
 
 
 http://example.com:8080, http://example.com:1337 {
   redir http://example.com{uri} permanent
 }
-
 

--- a/test/provision-test-proxy.yml
+++ b/test/provision-test-proxy.yml
@@ -5,7 +5,9 @@
   vars:
     caddy_sites:
     - domain: "example.com"
-      reverse_proxy: "192.168.50.2"
+      routes:
+        - path: ""
+          reverse_proxy_destination: "192.168.50.2"
       allowlist: &default_allowlist
         - "8.8.8.8/32"
       additional_forwarding_ports:


### PR DESCRIPTION
With this PR, you can define multiple routes per site so you can redirect them to different system. Therefore, the syntax for the role configuration will change by a bit, however, I think it's better than making the Jinja template even more complicated.