### PR TITLE
Add redirects directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Afterwards, you can define a list of `routes` composing of the following values:
 * `reverse_proxy_destination`: Where the requested should be proxied.
 * `strip_prefix`: If set, the matched `path` will be removed from the request to the destination system. This means, if somebody requests the route `/api/v1/hello` at the reverse proxy and you set `/api/*` as path, the request will be sent as `/v1/hello` to the destination system.
 
+Additionally, you can also define a list of `redirects` composing of the following values:
+
+* `source`: Path that should be matched. Let it empty for everything or e.g. `/api/*` for something specific.
+* `target`: Target location. Becomes the response's Location header.
+* `code`: HTTP status code to use for the redirect. Can be an integer in the 3xx range, or 401, `temporary` for temporary redirect (302), `permanent` for a permanent redirect (301, default), `html` to use an HTML document to perform the redirect (will redirect browsers, but not API clients).
+
 Certificates, domain etc. are always defined for one site and cannot be redefined for a route.
 
 ## Dependencies

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -12,6 +12,12 @@
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2
+        redirects:
+          - source: ''
+            target: /
+          - source: '/about-us'
+            target: '/about'
+            code: 401
         allowlist:
           - 8.8.8.8/32
         additional_forwarding_ports:

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -11,7 +11,9 @@ example.com {
   @not_allowlist {
     not remote_ip  8.8.8.8/32
   }
-  
+
+  redir / permanent
+  redir /about-us /about 401
   
   handle  {
     reverse_proxy @allowlist 192.168.50.2

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -15,6 +15,10 @@
   }
   {% endif %}
 
+  {%- for redir in site.redirects %}
+  redir {% if redir.source is defined and redir.source %}{{ redir.source }} {% endif %}{{ redir.target }}{% if redir.code is defined and redir.code%} {{ redir.code }}{% else %} permanent{% endif %}
+  {%- endfor %}
+
   {%- for route in site.routes %}
   {% if route.strip_prefix is defined and route.strip_prefix %}
   handle_path {{ route.path }} {


### PR DESCRIPTION
This PR adds a `redirects` section in each site that allows defining Caddy `redir` directives.