### PR TITLE
Check for redirects and additional_forwarding_port definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Basic installation:
     - role: simplificator.caddy
 ```
 
-With reverse proxy configuration:
+With reverse proxy configuration and redirects:
 
 ```yaml
 ---
@@ -67,6 +67,9 @@ With reverse proxy configuration:
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2
+        redirects:
+          - source: ''
+            target: '/'
         allowlist:
           - 8.8.8.8/32
         additional_forwarding_ports:

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -23,3 +23,7 @@
         additional_forwarding_ports:
           - '8080'
           - '1337'
+      - domain: test.com
+        routes:
+          - path: ''
+            reverse_proxy_destination: 192.168.50.1

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -27,3 +27,13 @@ http://example.com:8080, http://example.com:1337 {
   redir http://example.com{uri} permanent
 }
 
+
+test.com {
+
+  handle  {
+    reverse_proxy @allowlist 192.168.50.2
+    respond @not_allowlist 404
+  }
+  
+  }
+

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -41,7 +41,7 @@
   {% endif -%}
 }
 
-{% if site.additional_forwarding_ports | length > 0 %}
+{% if (site.additional_forwarding_port is defined) and (site.additional_forwarding_ports | length > 0) %}
 {{ (["http://"] | product([site.domain]) | map("join")) | product(site.additional_forwarding_ports) | map("join", ":") | join(", ") }} {
   redir http://{{ site.domain }}{uri} permanent
 }

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -15,9 +15,11 @@
   }
   {% endif %}
 
+  {%- if site.redirects is defined %}
   {%- for redir in site.redirects %}
   redir {% if redir.source is defined and redir.source %}{{ redir.source }} {% endif %}{{ redir.target }}{% if redir.code is defined and redir.code%} {{ redir.code }}{% else %} permanent{% endif %}
   {%- endfor %}
+  {%- endif %}
 
   {%- for route in site.routes %}
   {% if route.strip_prefix is defined and route.strip_prefix %}


### PR DESCRIPTION
This PR adds a check that `redirects ` and `additional_forwarding_port` is defined before trying to add them.
Without this check, a `site` definition without `redirects` or `additional_forwarding_port` directive would be invalid.