### PR TITLE
Add option to ignore `allow_list` for a certain route

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you only want to install Caddy, you don't need to set any variables. If you w
 Afterwards, you can define a list of `routes` composing of the following values:
 
 * `path`: Path that should be matched. Let it empty for everything or e.g. `/api/*` for something specific.
+* `public`: If `true` the site's `allowlist` will not be applied to this route, thus making this route publicly available. Defaults to `false`.
 * `reverse_proxy_destination`: Where the requested should be proxied.
 * `strip_prefix`: If set, the matched `path` will be removed from the request to the destination system. This means, if somebody requests the route `/api/v1/hello` at the reverse proxy and you set `/api/*` as path, the request will be sent as `/v1/hello` to the destination system.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you only want to install Caddy, you don't need to set any variables. If you w
 Afterwards, you can define a list of `routes` composing of the following values:
 
 * `path`: Path that should be matched. Let it empty for everything or e.g. `/api/*` for something specific.
-* `public`: If `true` the site's `allowlist` will not be applied to this route, thus making this route publicly available. Defaults to `false`.
+* `ignore_allowlist`: If `true` the site's `allowlist` will not be applied to this route, thus making this route publicly available. Defaults to `false`.
 * `reverse_proxy_destination`: Where the requested should be proxied.
 * `strip_prefix`: If set, the matched `path` will be removed from the request to the destination system. This means, if somebody requests the route `/api/v1/hello` at the reverse proxy and you set `/api/*` as path, the request will be sent as `/v1/hello` to the destination system.
 

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -28,3 +28,13 @@
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.1
+      - domain: mixed.example.com
+        routes:
+          - path: '/public/*'
+            ignore_allowlist: true
+            reverse_proxy_destination: 192.168.50.3
+          - path: '/protected/*'
+            strip_prefix: true
+            reverse_proxy_destination: 192.168.50.4
+        allowlist:
+          - 8.8.8.8/32

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -12,12 +12,13 @@ example.com {
     not remote_ip  8.8.8.8/32
   }
   
-  handle /basic/auth* {        
+  handle /basic/auth* {
   basicauth {
     Bob $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
-  }        
-  
+  }
+
   uri replace /basic/auth /api/auth
+
   reverse_proxy @allowlist the-api.com:3000
   respond @not_allowlist 404
 }
@@ -29,7 +30,8 @@ example.com {
     respond @not_allowlist 404
   }
   
-  }
+  
+}
 
 
 http://example.com:8080, http://example.com:1337 {
@@ -43,7 +45,33 @@ test.com {
     reverse_proxy 192.168.50.1
   }
   
+  
+}
+
+
+
+
+mixed.example.com {
+  @allowlist {
+    remote_ip  8.8.8.8/32
   }
+
+  @not_allowlist {
+    not remote_ip  8.8.8.8/32
+  }
+  
+  
+  handle /public/* {
+    reverse_proxy 192.168.50.3
+  }
+  
+  handle_path /protected/* {
+    reverse_proxy @allowlist 192.168.50.4
+    respond @not_allowlist 404
+  }
+  
+  
+}
 
 
 

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -31,7 +31,7 @@
   {%- else %}
   handle {{ route.path }} {
   {%- endif %}
-    {%- if site.allowlist is defined and not (route.public | default(false)) %}
+    {%- if site.allowlist is defined and not (route.ignore_allowlist| default(false)) %}
     reverse_proxy @allowlist {{ route.reverse_proxy_destination }}
     respond @not_allowlist 404
     {%- else %}

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -28,7 +28,7 @@
   {%- for route in site.routes %}
   {% if route.strip_prefix is defined and route.strip_prefix %}
   handle_path {{ route.path }} {
-  {% else %}
+  {%- else %}
   handle {{ route.path }} {
   {%- endif %}
     {%- if site.allowlist is defined and not (route.public | default(false)) %}
@@ -42,7 +42,7 @@
   
   {% if site.certificate_file is defined %}
   tls {{ site.certificate_file }} {{ site.certificate_key }}
-  {% endif -%}
+  {%- endif %}
 }
 
 {% if (site.additional_forwarding_ports is defined) and (site.additional_forwarding_ports | length > 0) %}

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -31,7 +31,7 @@
   {% else %}
   handle {{ route.path }} {
   {%- endif %}
-    {%- if site.allowlist is defined %}
+    {%- if site.allowlist is defined and not (route.public | default(false)) %}
     reverse_proxy @allowlist {{ route.reverse_proxy_destination }}
     respond @not_allowlist 404
     {%- else %}


### PR DESCRIPTION
There are cases where most of the routes should only be allowed for the IP addresses defined in `allowlist`, but certain routes should be available publicly.