### PR TITLE
Robin francois/master: Adding configuration elements to block based on user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ N/A
 If you only want to install Caddy, you don't need to set any variables. If you want to configure Caddy as a reverse proxy as well, you can provide an array of objects named `caddy_sites` with the following values:
 
 * `additional_forwarding_ports`: Allows to define a list with additional ports where Caddy should listen for this domain and forward to HTTPS.
-* `allowlist`: An array if IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
+* `allowlist`: An array of IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
+* `useragent_blocklist`: An array of User-Agents which are blocked to access this site (Optional).
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
 * `domain`: The domain caddy should listen to.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you only want to install Caddy, you don't need to set any variables. If you w
 
 * `additional_forwarding_ports`: Allows to define a list with additional ports where Caddy should listen for this domain and forward to HTTPS.
 * `allowlist`: An array of IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
-* `useragent_blocklist`: An array of User-Agents which are blocked to access this site (Optional).
+* `useragent_blocklist`: An array of User-Agents which are blocked to access this site (Optional), wildcard characters (*) need to be used for broader matching.
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
 * `domain`: The domain caddy should listen to.

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -20,6 +20,8 @@
             code: 401
         allowlist:
           - 8.8.8.8/32
+        useragent_blocklist:
+          - amazonbot
         additional_forwarding_ports:
           - '8080'
           - '1337'

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -21,7 +21,7 @@
         allowlist:
           - 8.8.8.8/32
         useragent_blocklist:
-          - amazonbot
+          - "*amazonbot*"
         additional_forwarding_ports:
           - '8080'
           - '1337'

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -4,6 +4,14 @@
 
 
 example.com {
+  @badbots {
+    header User-Agent *amazonbot*
+  }
+
+  handle @badbots {
+    abort
+  }
+
   @allowlist {
     remote_ip  8.8.8.8/32
   }

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -9,7 +9,9 @@ example.com {
   }
 
   handle @badbots {
-    abort
+      respond 403 {
+          body "Access forbidden."
+      }
   }
 
   @allowlist {

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -5,17 +5,17 @@
 
 {% for site in caddy_sites %}
 {{ site.domain }} {
-  {% if site.useragent_blocklist is defined %}
+  {%- if site.useragent_blocklist is defined %}
   @badbots {
-    {% for ua in site.useragent_blocklist %}
+    {%- for ua in site.useragent_blocklist %}
     header User-Agent *{{ ua }}*
-    {% endfor %}
+    {%- endfor %}
   }
 
   handle @badbots {
     abort
   }
-  {% endif %}
+  {%- endif %}
 
   {%- if site.allowlist is defined %}
   @allowlist {

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -13,8 +13,11 @@
   }
 
   handle @badbots {
-    abort
+      respond 403 {
+          body "Access forbidden."
+      }
   }
+
   {%- endif %}
 
   {%- if site.allowlist is defined %}

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -5,6 +5,19 @@
 
 {% for site in caddy_sites %}
 {{ site.domain }} {
+
+  {% if site.useragent_blocklist is defined %}
+  @badbots {
+    {% for ua in site.useragent_blocklist %}
+    header User-Agent *{{ ua }}*
+    {% endfor %}
+  }
+
+  handle @badbots {
+    abort
+  }
+  {% endif %}
+
   {%- if site.allowlist is defined %}
   @allowlist {
     remote_ip {% for ip in site.allowlist %} {{ ip }}{% endfor %}

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -5,7 +5,6 @@
 
 {% for site in caddy_sites %}
 {{ site.domain }} {
-
   {% if site.useragent_blocklist is defined %}
   @badbots {
     {% for ua in site.useragent_blocklist %}

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -8,7 +8,7 @@
   {%- if site.useragent_blocklist is defined %}
   @badbots {
     {%- for ua in site.useragent_blocklist %}
-    header User-Agent *{{ ua }}*
+    header User-Agent {{ ua }}
     {%- endfor %}
   }
 


### PR DESCRIPTION
This PR was forged by a rebase onto master. It consists only of the changes from #20 

## From #20 
With the increase of traffic generated by generative AI robots, and since those bots do not respect the robots.txt, user-agent filtering seems at the moment a good approach to prevent services being overloaded.

This PR adds a new variable to configure a block list of user agents. This list is case sensitive.