### PR TITLE
Add default response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you only want to install Caddy, you don't need to set any variables. If you w
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
 * `domain`: The domain caddy should listen to.
+* `default_response_code`: The code caddy will respond if the route is not defined. If not set, Caddy default behavior responds with code `200`.
 
 Afterwards, you can define a list of `routes` composing of the following values:
 

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -9,6 +9,7 @@
   vars:
     caddy_sites:
       - domain: example.com
+        default_response_code: 404
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2

--- a/molecule/reverse-proxy/files/Caddyfile.expected
+++ b/molecule/reverse-proxy/files/Caddyfile.expected
@@ -40,7 +40,7 @@ example.com {
     respond @not_allowlist 404
   }
   
-  
+  respond 404
 }
 
 

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -58,6 +58,10 @@
   {% if site.certificate_file is defined %}
   tls {{ site.certificate_file }} {{ site.certificate_key }}
   {%- endif %}
+
+  {% if site.default_response_code is defined %}
+  respond {{ site.default_response_code }}
+  {%- endif %}
 }
 
 {% if (site.additional_forwarding_ports is defined) and (site.additional_forwarding_ports | length > 0) %}


### PR DESCRIPTION
This PR adds a new parameter that allows the default response code to be set.

This role is used with routes and reverse proxies. When a user requests a non-existing route or "/," Caddy responds with code 200. This is not always the desired behavior.