### PR TITLE
Move allowlist from site to route

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ N/A
 If you only want to install Caddy, you don't need to set any variables. If you want to configure Caddy as a reverse proxy as well, you can provide an array of objects named `caddy_sites` with the following values:
 
 * `additional_forwarding_ports`: Allows to define a list with additional ports where Caddy should listen for this domain and forward to HTTPS.
-* `allowlist`: An array of IP addresses in CIDR-notation which are allowed to access this site (Optional). All other visitors receive a 404 error.
+* `allowlist`: An array if IP addresses in CIDR-notation which are allowed to access this route (Optional). All other visitors receive a 404 error.
 * `useragent_blocklist`: An array of User-Agents which are blocked to access this site (Optional), wildcard characters (*) need to be used for broader matching.
 * `certificate_file`: You can set this variable if you want to provide the certificate by yourself (Optional). The certificate needs permissions `0640`, with root as Owner and Caddy as Group.
 * `certificate_key`: You can set this variable if you want to provide the certificate by yourself (Optional).
@@ -73,11 +73,11 @@ With reverse proxy configuration and redirects:
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2
+            allowlist:
+              - 8.8.8.8/32
         redirects:
           - source: ''
             target: '/'
-        allowlist:
-          - 8.8.8.8/32
         additional_forwarding_ports:
           - '8080'
           - '1337'

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ With reverse proxy configuration and redirects:
   vars:
     caddy_sites:
       - domain: example.com
+        tls_insecure: true
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -14,6 +14,8 @@
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2
+            allowlist:
+              - 8.8.8.8/32
         redirects:
           - source: ''
             target: /
@@ -37,8 +39,10 @@
           - path: '/public/*'
             ignore_allowlist: true
             reverse_proxy_destination: 192.168.50.3
+            allowlist:
+              - 8.8.8.8/32
           - path: '/protected/*'
             strip_prefix: true
             reverse_proxy_destination: 192.168.50.4
-        allowlist:
-          - 8.8.8.8/32
+            allowlist:
+              - 8.8.8.8/32

--- a/molecule/reverse-proxy/converge.yml
+++ b/molecule/reverse-proxy/converge.yml
@@ -10,6 +10,7 @@
     caddy_sites:
       - domain: example.com
         default_response_code: 404
+        tls_insecure: false
         routes:
           - path: ''
             reverse_proxy_destination: 192.168.50.2

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -20,15 +20,17 @@
 
   {%- endif %}
 
-  {%- if site.allowlist is defined %}
-  @allowlist {
-    remote_ip {% for ip in site.allowlist %} {{ ip }}{% endfor %}
+  {% for route in site.routes %}
+  {%- if route.allowlist is defined%}
+  @allowlist{{loop.index}} {
+    remote_ip {% for ip in route.allowlist %} {{ ip }}{% endfor %}
   }
 
-  @not_allowlist {
-    not remote_ip {% for ip in site.allowlist %} {{ ip }}{% endfor %}
+  @not_allowlist{{loop.index}} {
+    not remote_ip {% for ip in route.allowlist %} {{ ip }}{% endfor %}
   }
   {% endif %}
+  {% endfor %}
 
   {%- if site.additional_template_path is defined %}
   {% include site.additional_template_path %}
@@ -46,13 +48,13 @@
   {%- else %}
   handle {{ route.path }} {
   {%- endif %}
-    {%- if site.allowlist is defined and not (route.ignore_allowlist| default(false)) %}
-    reverse_proxy @allowlist {{ route.reverse_proxy_destination }}{%- if site.tls_insecure%} {
+    {%- if route.allowlist is defined and not (route.ignore_allowlist| default(false)) %}
+    reverse_proxy @allowlist{{loop.index}} {{ route.reverse_proxy_destination }}{%- if site.tls_insecure%} {
       transport http {
           tls_insecure_skip_verify
       }
     }{%- endif %}
-    respond @not_allowlist 404
+    respond @not_allowlist{{loop.index}} 404
     {%- else %}
     reverse_proxy {{ route.reverse_proxy_destination }}{%- if site.tls_insecure%} {
       transport http {

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -47,10 +47,18 @@
   handle {{ route.path }} {
   {%- endif %}
     {%- if site.allowlist is defined and not (route.ignore_allowlist| default(false)) %}
-    reverse_proxy @allowlist {{ route.reverse_proxy_destination }}
+    reverse_proxy @allowlist {{ route.reverse_proxy_destination }}{%- if site.tls_insecure%} {
+      transport http {
+          tls_insecure_skip_verify
+      }
+    }{%- endif %}
     respond @not_allowlist 404
     {%- else %}
-    reverse_proxy {{ route.reverse_proxy_destination }}
+    reverse_proxy {{ route.reverse_proxy_destination }}{%- if site.tls_insecure%} {
+      transport http {
+          tls_insecure_skip_verify
+      }
+    }{%- endif %}
     {%- endif %}
   }
   {%- endfor %}


### PR DESCRIPTION
Move allowlist from site to route - syntax change!

This PR was merged and reverted before. Please consider this for more granular control.
I understand if the change in syntax is not ideal, proposals for backward compatibility are welcome.
For my use case this level of detail is needed and since caddy supports it, I consider it an improvement.
Thank you